### PR TITLE
Refactor caching implementation to use custom wrapper

### DIFF
--- a/DbLocator/DbLocator.cs
+++ b/DbLocator/DbLocator.cs
@@ -53,7 +53,7 @@ public partial class Locator
         _databases = new Databases(dbContextFactory, dbLocatorCache);
         _databaseServers = new DatabaseServers(dbContextFactory, dbLocatorCache);
         _databaseUsers = new DatabaseUsers(dbContextFactory, encryption, dbLocatorCache);
-        _databaseUserRoles = new DatabaseUserRoles(dbContextFactory);
+        _databaseUserRoles = new DatabaseUserRoles(dbContextFactory, dbLocatorCache);
         _databaseTypes = new DatabaseTypes(dbContextFactory, dbLocatorCache);
         _tenants = new Tenants(dbContextFactory, dbLocatorCache);
     }

--- a/DbLocator/DbLocator.cs
+++ b/DbLocator/DbLocator.cs
@@ -47,13 +47,15 @@ public partial class Locator
         var dbContextFactory = DbContextFactory.CreateDbContextFactory(dbLocatorConnectionString);
         var encryption = new Encryption(encryptionKey);
 
-        _connections = new Connections(dbContextFactory, encryption, distributedCache);
-        _databases = new Databases(dbContextFactory, distributedCache);
-        _databaseServers = new DatabaseServers(dbContextFactory, distributedCache);
-        _databaseUsers = new DatabaseUsers(dbContextFactory, encryption, distributedCache);
+        var dbLocatorCache = new DbLocatorCache(distributedCache);
+
+        _connections = new Connections(dbContextFactory, encryption, dbLocatorCache);
+        _databases = new Databases(dbContextFactory, dbLocatorCache);
+        _databaseServers = new DatabaseServers(dbContextFactory, dbLocatorCache);
+        _databaseUsers = new DatabaseUsers(dbContextFactory, encryption, dbLocatorCache);
         _databaseUserRoles = new DatabaseUserRoles(dbContextFactory);
-        _databaseTypes = new DatabaseTypes(dbContextFactory, distributedCache);
-        _tenants = new Tenants(dbContextFactory, distributedCache);
+        _databaseTypes = new DatabaseTypes(dbContextFactory, dbLocatorCache);
+        _tenants = new Tenants(dbContextFactory, dbLocatorCache);
     }
 
     /// <summary>

--- a/DbLocator/Features/Connections/AddConnection.cs
+++ b/DbLocator/Features/Connections/AddConnection.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Connections;
 
@@ -18,7 +18,7 @@ internal sealed class AddConnectionCommandValidator : AbstractValidator<AddConne
 
 internal class AddConnection(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task<int> Handle(AddConnectionCommand command)

--- a/DbLocator/Features/Connections/DeleteConnection.cs
+++ b/DbLocator/Features/Connections/DeleteConnection.cs
@@ -40,5 +40,6 @@ internal class DeleteConnection(
         await dbContext.SaveChangesAsync();
 
         cache?.Remove("connections");
+        cache?.TryClearConnectionStringFromCache(ConnectionId: command.ConnectionId);
     }
 }

--- a/DbLocator/Features/Connections/DeleteConnection.cs
+++ b/DbLocator/Features/Connections/DeleteConnection.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Connections;
 
@@ -19,7 +19,7 @@ internal sealed class DeleteConnectionCommandValidator : AbstractValidator<Delet
 
 internal class DeleteConnection(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task Handle(DeleteConnectionCommand command)

--- a/DbLocator/Features/Connections/GetConnection.cs
+++ b/DbLocator/Features/Connections/GetConnection.cs
@@ -32,7 +32,7 @@ internal class GetConnection(
 
         // Override the default toString so I can control it
         var queryString =
-            @$"TenandId:{query.TenantId},
+            @$"TenantId:{query.TenantId},
             DatabaseTypeId:{query.DatabaseTypeId},
             ConnectionId:{query.ConnectionId},
             TenantCode:{query.TenantCode}

--- a/DbLocator/Features/Connections/GetConnection.cs
+++ b/DbLocator/Features/Connections/GetConnection.cs
@@ -30,7 +30,14 @@ internal class GetConnection(
     {
         await new GetConnectionQueryValidator().ValidateAndThrowAsync(query);
 
-        var cacheKey = $"connection:{query}";
+        // Override the default toString so I can control it
+        var queryString =
+            @$"TenandId:{query.TenantId},
+            DatabaseTypeId:{query.DatabaseTypeId},
+            ConnectionId:{query.ConnectionId},
+            TenantCode:{query.TenantCode}
+            Roles:{string.Join(",", query.Roles)}";
+        var cacheKey = $"connection:{queryString}";
         var cachedData = await GetCachedData(cacheKey);
 
         if (!string.IsNullOrEmpty(cachedData))

--- a/DbLocator/Features/Connections/GetConnection.cs
+++ b/DbLocator/Features/Connections/GetConnection.cs
@@ -37,29 +37,18 @@ internal class GetConnection(
             ConnectionId:{query.ConnectionId},
             TenantCode:{query.TenantCode}
             Roles:{string.Join(",", query.Roles)}";
-        var cacheKey = $"connection:{queryString}";
-        var cachedData = await GetCachedData(cacheKey);
 
+        var cacheKey = $"connection:{queryString}";
+        var cachedData = await cache?.GetCachedData<string>(cacheKey);
         if (!string.IsNullOrEmpty(cachedData))
+        {
             return new SqlConnection(cachedData);
+        }
 
         var connectionString = await GetConnectionStringFromDatabase(query);
-        await CacheData(cacheKey, connectionString);
+        await cache?.CacheConnectionString(cacheKey, connectionString);
 
         return new SqlConnection(connectionString);
-    }
-
-    private async Task<string> GetCachedData(string cacheKey)
-    {
-        return cache != null ? await cache.GetCachedData<string>(cacheKey) : null;
-    }
-
-    private async Task CacheData(string cacheKey, string connectionString)
-    {
-        if (cache != null)
-        {
-            await cache.CacheData(cacheKey, connectionString);
-        }
     }
 
     private async Task<string> GetConnectionStringFromDatabase(GetConnectionQuery query)

--- a/DbLocator/Features/Connections/GetConnections.cs
+++ b/DbLocator/Features/Connections/GetConnections.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Connections;
 
@@ -16,7 +16,7 @@ internal sealed class GetConnectionsQueryValidator : AbstractValidator<GetConnec
 
 internal class GetConnections(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task<List<Connection>> Handle(GetConnectionsQuery query)
@@ -37,7 +37,7 @@ internal class GetConnections(
 
     private async Task<string> GetCachedData(string cacheKey)
     {
-        return cache != null ? await cache.GetStringAsync(cacheKey) : null;
+        return cache != null ? await cache.GetCachedData<string>(cacheKey) : null;
     }
 
     private static List<Connection> DeserializeCachedData(string cachedData)
@@ -50,7 +50,7 @@ internal class GetConnections(
         if (cache != null)
         {
             var serializedData = JsonSerializer.Serialize(connections);
-            await cache.SetStringAsync(cacheKey, serializedData);
+            await cache.CacheData(cacheKey, serializedData);
         }
     }
 

--- a/DbLocator/Features/Connections/GetConnections.cs
+++ b/DbLocator/Features/Connections/GetConnections.cs
@@ -24,34 +24,16 @@ internal class GetConnections(
         await new GetConnectionsQueryValidator().ValidateAndThrowAsync(query);
 
         var cacheKey = "connections";
-        var cachedData = await GetCachedData(cacheKey);
-
-        if (!string.IsNullOrEmpty(cachedData))
-            return DeserializeCachedData(cachedData);
+        var cachedData = await cache?.GetCachedData<List<Connection>>(cacheKey);
+        if (cachedData != null)
+        {
+            return cachedData;
+        }
 
         var connections = await GetConnectionsFromDatabase(dbContextFactory);
-        await CacheData(cacheKey, connections);
+        await cache?.CacheData(cacheKey, connections);
 
         return connections;
-    }
-
-    private async Task<string> GetCachedData(string cacheKey)
-    {
-        return cache != null ? await cache.GetCachedData<string>(cacheKey) : null;
-    }
-
-    private static List<Connection> DeserializeCachedData(string cachedData)
-    {
-        return JsonSerializer.Deserialize<List<Connection>>(cachedData) ?? new List<Connection>();
-    }
-
-    private async Task CacheData(string cacheKey, List<Connection> connections)
-    {
-        if (cache != null)
-        {
-            var serializedData = JsonSerializer.Serialize(connections);
-            await cache.CacheData(cacheKey, serializedData);
-        }
     }
 
     private static async Task<List<Connection>> GetConnectionsFromDatabase(

--- a/DbLocator/Features/DatabaseServers/AddDatabaseServer.cs
+++ b/DbLocator/Features/DatabaseServers/AddDatabaseServer.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseServers;
 
@@ -44,7 +44,7 @@ internal sealed class AddDatabaseServerCommandValidator
 
 internal class AddDatabaseServer(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     private readonly IDbContextFactory<DbLocatorContext> _dbContextFactory = dbContextFactory;

--- a/DbLocator/Features/DatabaseServers/DeleteDatabaseServer.cs
+++ b/DbLocator/Features/DatabaseServers/DeleteDatabaseServer.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseServers;
 
@@ -18,7 +18,7 @@ internal sealed class DeleteDatabaseServerCommandValidator
 
 internal class DeleteDatabaseServer(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task Handle(DeleteDatabaseServerCommand command)

--- a/DbLocator/Features/DatabaseServers/GetDatabaseServers.cs
+++ b/DbLocator/Features/DatabaseServers/GetDatabaseServers.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseServers;
 
@@ -16,7 +16,7 @@ internal sealed class GetDatabaseServersQueryValidator : AbstractValidator<GetDa
 
 internal class GetDatabaseServers(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task<List<DatabaseServer>> Handle(GetDatabaseServersQuery query)
@@ -37,7 +37,7 @@ internal class GetDatabaseServers(
 
     private async Task<string> GetCachedData(string cacheKey)
     {
-        return cache != null ? await cache.GetStringAsync(cacheKey) : null;
+        return cache != null ? await cache.GetCachedData<string>(cacheKey) : null;
     }
 
     private static List<DatabaseServer> DeserializeCachedData(string cachedData)
@@ -50,7 +50,7 @@ internal class GetDatabaseServers(
         if (cache != null)
         {
             var serializedData = JsonSerializer.Serialize(databaseServers);
-            await cache.SetStringAsync(cacheKey, serializedData);
+            await cache.CacheData(cacheKey, serializedData);
         }
     }
 

--- a/DbLocator/Features/DatabaseServers/GetDatabaseServers.cs
+++ b/DbLocator/Features/DatabaseServers/GetDatabaseServers.cs
@@ -24,34 +24,16 @@ internal class GetDatabaseServers(
         await new GetDatabaseServersQueryValidator().ValidateAndThrowAsync(query);
 
         var cacheKey = "databaseServers";
-        var cachedData = await GetCachedData(cacheKey);
-
-        if (!string.IsNullOrEmpty(cachedData))
-            return DeserializeCachedData(cachedData);
+        var cachedData = await cache?.GetCachedData<List<DatabaseServer>>(cacheKey);
+        if (cachedData != null)
+        {
+            return cachedData;
+        }
 
         var databaseServers = await GetDatabaseServersFromDatabase(dbContextFactory);
-        await CacheData(cacheKey, databaseServers);
+        await cache?.CacheData(cacheKey, databaseServers);
 
         return databaseServers;
-    }
-
-    private async Task<string> GetCachedData(string cacheKey)
-    {
-        return cache != null ? await cache.GetCachedData<string>(cacheKey) : null;
-    }
-
-    private static List<DatabaseServer> DeserializeCachedData(string cachedData)
-    {
-        return JsonSerializer.Deserialize<List<DatabaseServer>>(cachedData) ?? [];
-    }
-
-    private async Task CacheData(string cacheKey, List<DatabaseServer> databaseServers)
-    {
-        if (cache != null)
-        {
-            var serializedData = JsonSerializer.Serialize(databaseServers);
-            await cache.CacheData(cacheKey, serializedData);
-        }
     }
 
     private static async Task<List<DatabaseServer>> GetDatabaseServersFromDatabase(

--- a/DbLocator/Features/DatabaseServers/UpdateDatabaseServer.cs
+++ b/DbLocator/Features/DatabaseServers/UpdateDatabaseServer.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseServers;
 
@@ -46,7 +46,7 @@ internal sealed class UpdateDatabaseServerCommandValidator
 
 internal class UpdateDatabaseServer(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task Handle(UpdateDatabaseServerCommand command)

--- a/DbLocator/Features/DatabaseTypes/AddDatabaseType.cs
+++ b/DbLocator/Features/DatabaseTypes/AddDatabaseType.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseTypes;
 
@@ -21,7 +21,7 @@ internal sealed class AddDatabaseTypeCommandValidator : AbstractValidator<AddDat
 
 internal class AddDatabaseType(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task<byte> Handle(AddDatabaseTypeCommand command)

--- a/DbLocator/Features/DatabaseTypes/DeleteDatabaseType.cs
+++ b/DbLocator/Features/DatabaseTypes/DeleteDatabaseType.cs
@@ -48,6 +48,7 @@ internal class DeleteDatabaseType(
         await dbContext.SaveChangesAsync();
 
         cache?.Remove("databaseTypes");
+        cache?.Remove("connections");
         cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseType.DatabaseTypeId);
     }
 }

--- a/DbLocator/Features/DatabaseTypes/DeleteDatabaseType.cs
+++ b/DbLocator/Features/DatabaseTypes/DeleteDatabaseType.cs
@@ -48,5 +48,6 @@ internal class DeleteDatabaseType(
         await dbContext.SaveChangesAsync();
 
         cache?.Remove("databaseTypes");
+        cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseType.DatabaseTypeId);
     }
 }

--- a/DbLocator/Features/DatabaseTypes/DeleteDatabaseType.cs
+++ b/DbLocator/Features/DatabaseTypes/DeleteDatabaseType.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseTypes;
 
@@ -18,7 +18,7 @@ internal sealed class DeleteDatabaseTypeCommandValidator
 
 internal class DeleteDatabaseType(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task Handle(DeleteDatabaseTypeCommand command)

--- a/DbLocator/Features/DatabaseTypes/GetDatabaseTypes.cs
+++ b/DbLocator/Features/DatabaseTypes/GetDatabaseTypes.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseTypes;
 
@@ -16,7 +16,7 @@ internal sealed class GetDatabaseTypesQueryValidator : AbstractValidator<GetData
 
 internal class GetDatabaseTypes(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task<List<DatabaseType>> Handle(GetDatabaseTypesQuery query)
@@ -37,7 +37,7 @@ internal class GetDatabaseTypes(
 
     private async Task<string> GetCachedData(string cacheKey)
     {
-        return cache != null ? await cache.GetStringAsync(cacheKey) : null;
+        return cache != null ? await cache.GetCachedData<string>(cacheKey) : null;
     }
 
     private static List<DatabaseType> DeserializeCachedData(string cachedData)
@@ -50,7 +50,7 @@ internal class GetDatabaseTypes(
         if (cache != null)
         {
             var serializedData = JsonSerializer.Serialize(databaseTypes);
-            await cache.SetStringAsync(cacheKey, serializedData);
+            await cache.CacheData(cacheKey, serializedData);
         }
     }
 

--- a/DbLocator/Features/DatabaseTypes/UpdateDatabaseType.cs
+++ b/DbLocator/Features/DatabaseTypes/UpdateDatabaseType.cs
@@ -47,5 +47,6 @@ internal class UpdateDatabaseType(
         await dbContext.SaveChangesAsync();
 
         cache?.Remove("databaseTypes");
+        cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseType.DatabaseTypeId);
     }
 }

--- a/DbLocator/Features/DatabaseTypes/UpdateDatabaseType.cs
+++ b/DbLocator/Features/DatabaseTypes/UpdateDatabaseType.cs
@@ -47,6 +47,7 @@ internal class UpdateDatabaseType(
         await dbContext.SaveChangesAsync();
 
         cache?.Remove("databaseTypes");
+        cache?.Remove("connections");
         cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseType.DatabaseTypeId);
     }
 }

--- a/DbLocator/Features/DatabaseTypes/UpdateDatabaseType.cs
+++ b/DbLocator/Features/DatabaseTypes/UpdateDatabaseType.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseTypes;
 
@@ -23,7 +23,7 @@ internal sealed class UpdateDatabaseTypeCommandValidator
 
 internal class UpdateDatabaseType(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task Handle(UpdateDatabaseTypeCommand command)

--- a/DbLocator/Features/DatabaseUserRoles/DeleteDatabaseUserRole.cs
+++ b/DbLocator/Features/DatabaseUserRoles/DeleteDatabaseUserRole.cs
@@ -1,5 +1,6 @@
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 
@@ -24,7 +25,10 @@ namespace DbLocator.Features.DatabaseUserRoles
         }
     }
 
-    internal class DeleteDatabaseUserRole(IDbContextFactory<DbLocatorContext> dbContextFactory)
+    internal class DeleteDatabaseUserRole(
+        IDbContextFactory<DbLocatorContext> dbContextFactory,
+        DbLocatorCache cache
+    )
     {
         internal async Task Handle(DeleteDatabaseUserRoleCommand command)
         {
@@ -51,6 +55,7 @@ namespace DbLocator.Features.DatabaseUserRoles
             dbContext.Set<DatabaseUserRoleEntity>().Remove(databaseUserRoleEntity);
             await dbContext.SaveChangesAsync();
 
+            cache?.TryClearConnectionStringFromCache(Roles: [command.UserRole]);
             if (!command.DeleteDatabaseUserRole)
             {
                 return;

--- a/DbLocator/Features/DatabaseUsers/AddDatabaseUser.cs
+++ b/DbLocator/Features/DatabaseUsers/AddDatabaseUser.cs
@@ -2,7 +2,6 @@ using DbLocator.Db;
 using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseUsers;
 
@@ -44,7 +43,7 @@ internal sealed class AddDatabaseUserCommandValidator : AbstractValidator<AddDat
 internal class AddDatabaseUser(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
     Encryption encryption,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task<int> Handle(AddDatabaseUserCommand command)

--- a/DbLocator/Features/DatabaseUsers/DeleteDatabaseUser.cs
+++ b/DbLocator/Features/DatabaseUsers/DeleteDatabaseUser.cs
@@ -1,4 +1,5 @@
 using DbLocator.Db;
+using DbLocator.Domain;
 using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
@@ -46,6 +47,11 @@ namespace DbLocator.Features.DatabaseUsers
             await dbContext.SaveChangesAsync();
 
             cache?.Remove("databaseUsers");
+
+            var roles = databaseUserEntity
+                .UserRoles.Select(ur => (DatabaseRole)ur.DatabaseRoleId)
+                .ToArray();
+            cache?.TryClearConnectionStringFromCache(Roles: roles);
 
             if (!command.DeleteDatabaseUser)
             {

--- a/DbLocator/Features/DatabaseUsers/DeleteDatabaseUser.cs
+++ b/DbLocator/Features/DatabaseUsers/DeleteDatabaseUser.cs
@@ -66,29 +66,40 @@ namespace DbLocator.Features.DatabaseUsers
             DatabaseUserEntity databaseUserEntity
         )
         {
-            var database = await dbContext
-                .Set<DatabaseEntity>()
-                .Include(d => d.DatabaseServer)
-                .FirstOrDefaultAsync(ds => ds.DatabaseId == databaseUserEntity.DatabaseId);
+            var database =
+                await dbContext
+                    .Set<DatabaseEntity>()
+                    .Include(d => d.DatabaseServer)
+                    .FirstOrDefaultAsync(ds => ds.DatabaseId == databaseUserEntity.DatabaseId)
+                ?? throw new InvalidOperationException("Database not found.");
+
+            var dbName = Sql.SanitizeSqlIdentifier(database.DatabaseName);
+            var userName = Sql.EscapeForDynamicSql(
+                Sql.SanitizeSqlIdentifier(databaseUserEntity.UserName)
+            );
 
             var commands = new List<string>
             {
-                $"use {database.DatabaseName}; drop user {databaseUserEntity.UserName}",
-                $"drop login {databaseUserEntity.UserName}"
+                $"use [{dbName}]; drop user [{userName}]",
+                $"drop login [{userName}]"
             };
 
-            for (var i = 0; i < commands.Count; i++)
+            foreach (var rawCommand in commands)
             {
-                var commandText = commands[i];
-                using var cmd = dbContext.Database.GetDbConnection().CreateCommand();
+                var commandText = rawCommand;
 
                 if (database.DatabaseServer.IsLinkedServer)
                 {
+                    var linkedServer = Sql.SanitizeSqlIdentifier(
+                        database.DatabaseServer.DatabaseServerHostName
+                    );
                     commandText =
-                        $"exec('{commandText.Replace("'", "''")}') at {database.DatabaseServer.DatabaseServerHostName};";
+                        $"exec('{Sql.EscapeForDynamicSql(commandText)}') at [{linkedServer}];";
                 }
 
+                using var cmd = dbContext.Database.GetDbConnection().CreateCommand();
                 cmd.CommandText = commandText;
+
                 await dbContext.Database.OpenConnectionAsync();
                 await cmd.ExecuteNonQueryAsync();
             }

--- a/DbLocator/Features/DatabaseUsers/DeleteDatabaseUser.cs
+++ b/DbLocator/Features/DatabaseUsers/DeleteDatabaseUser.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseUsers
 {
@@ -18,7 +18,7 @@ namespace DbLocator.Features.DatabaseUsers
 
     internal class DeleteDatabaseUser(
         IDbContextFactory<DbLocatorContext> dbContextFactory,
-        IDistributedCache cache
+        DbLocatorCache cache
     )
     {
         internal async Task Handle(DeleteDatabaseUserCommand command)

--- a/DbLocator/Features/DatabaseUsers/GetDatabasesUsers.cs
+++ b/DbLocator/Features/DatabaseUsers/GetDatabasesUsers.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseUsers;
 
@@ -16,7 +16,7 @@ internal sealed class GetDatabaseUsersQueryValidator : AbstractValidator<GetData
 
 internal class GetDatabaseUsers(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     public async Task<List<DatabaseUser>> Handle(GetDatabaseUsersQuery query)
@@ -37,7 +37,7 @@ internal class GetDatabaseUsers(
 
     private async Task<string> GetCachedData(string cacheKey)
     {
-        return cache != null ? await cache.GetStringAsync(cacheKey) : null;
+        return cache != null ? await cache.GetCachedData<string>(cacheKey) : null;
     }
 
     private static List<DatabaseUser> DeserializeCachedData(string cachedData)
@@ -50,7 +50,7 @@ internal class GetDatabaseUsers(
         if (cache != null)
         {
             var serializedData = JsonSerializer.Serialize(databaseUsers);
-            await cache.SetStringAsync(cacheKey, serializedData);
+            await cache.CacheData(cacheKey, serializedData);
         }
     }
 

--- a/DbLocator/Features/DatabaseUsers/UpdateDatabaseUser.cs
+++ b/DbLocator/Features/DatabaseUsers/UpdateDatabaseUser.cs
@@ -3,7 +3,6 @@ using DbLocator.Domain;
 using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.DatabaseUsers;
 
@@ -46,7 +45,7 @@ internal sealed class UpdateDatabaseUserCommandValidator
 internal class UpdateDatabaseUser(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
     Encryption encryption,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task Handle(UpdateDatabaseUserCommand command)

--- a/DbLocator/Features/DatabaseUsers/UpdateDatabaseUser.cs
+++ b/DbLocator/Features/DatabaseUsers/UpdateDatabaseUser.cs
@@ -143,5 +143,10 @@ internal class UpdateDatabaseUser(
         }
 
         cache?.Remove("databaseUsers");
+
+        var roles = databaseUserEntity
+            .UserRoles.Select(ur => (DatabaseRole)ur.DatabaseRoleId)
+            .ToArray();
+        cache?.TryClearConnectionStringFromCache(Roles: roles);
     }
 }

--- a/DbLocator/Features/Databases/AddDatabase.cs
+++ b/DbLocator/Features/Databases/AddDatabase.cs
@@ -1,8 +1,8 @@
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Databases;
 
@@ -35,7 +35,7 @@ internal sealed class AddDatabaseCommandValidator : AbstractValidator<AddDatabas
 
 internal class AddDatabase(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task<int> Handle(AddDatabaseCommand command)

--- a/DbLocator/Features/Databases/DeleteDatabase.cs
+++ b/DbLocator/Features/Databases/DeleteDatabase.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Databases
 {
@@ -17,7 +17,7 @@ namespace DbLocator.Features.Databases
 
     internal class DeleteDatabase(
         IDbContextFactory<DbLocatorContext> dbContextFactory,
-        IDistributedCache cache
+        DbLocatorCache cache
     )
     {
         internal async Task Handle(DeleteDatabaseCommand command)

--- a/DbLocator/Features/Databases/DeleteDatabase.cs
+++ b/DbLocator/Features/Databases/DeleteDatabase.cs
@@ -46,6 +46,9 @@ namespace DbLocator.Features.Databases
                 await DeleteDatabaseAsync(dbContext, databaseEntity);
 
             cache?.Remove("databases");
+
+            // TODO: Make this more specific
+            cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseEntity.DatabaseTypeId);
         }
 
         private static async Task DeleteDatabaseAsync(

--- a/DbLocator/Features/Databases/DeleteDatabase.cs
+++ b/DbLocator/Features/Databases/DeleteDatabase.cs
@@ -48,6 +48,7 @@ namespace DbLocator.Features.Databases
                 await DeleteDatabaseAsync(dbContext, databaseEntity);
 
             cache?.Remove("databases");
+            cache?.Remove("connections");
 
             // TODO: Make this more specific
             cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseEntity.DatabaseTypeId);

--- a/DbLocator/Features/Databases/DeleteDatabase.cs
+++ b/DbLocator/Features/Databases/DeleteDatabase.cs
@@ -35,22 +35,21 @@ namespace DbLocator.Features.Databases
                     .Set<ConnectionEntity>()
                     .AnyAsync(c => c.DatabaseId == command.DatabaseId)
             )
+            {
                 throw new InvalidOperationException(
                     "Database is being used in Connection table, please remove the connection first if you want to delete this database."
                 );
+            }
 
             dbContext.Set<DatabaseEntity>().Remove(databaseEntity);
             await dbContext.SaveChangesAsync();
 
             if (command.DeleteDatabase == true)
+            {
                 await DeleteDatabaseAsync(dbContext, databaseEntity);
+            }
 
             cache?.Remove("databases");
-
-            // TODO: Make this more specific
-            cache?.TryClearConnectionStringFromCache(
-                DatabaseTypeId: (int)databaseEntity.DatabaseTypeId
-            );
         }
 
         private static async Task DeleteDatabaseAsync(

--- a/DbLocator/Features/Databases/DeleteDatabase.cs
+++ b/DbLocator/Features/Databases/DeleteDatabase.cs
@@ -46,40 +46,43 @@ namespace DbLocator.Features.Databases
 
             if (command.DeleteDatabase == true)
             {
-                await DeleteDatabaseAsync(dbContext, databaseEntity);
+                //await DeleteDatabaseAsync(dbContext, databaseEntity);
             }
 
             cache?.Remove("databases");
+
+            // TODO: Make this more specific
+            cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseEntity.DatabaseTypeId);
         }
 
-        private static async Task DeleteDatabaseAsync(
-            DbLocatorContext dbContext,
-            DatabaseEntity databaseEntity
-        )
-        {
-            var databaseName = Sql.SanitizeSqlIdentifier(databaseEntity.DatabaseName);
-            var rawCommand = $"drop database [{databaseName}]";
+        // private static async Task DeleteDatabaseAsync(
+        //     DbLocatorContext dbContext,
+        //     DatabaseEntity databaseEntity
+        // )
+        // {
+        //     var databaseName = Sql.SanitizeSqlIdentifier(databaseEntity.DatabaseName);
+        //     var rawCommand = $"drop database [{databaseName}]";
 
-            var databaseServer = await dbContext
-                .Set<DatabaseServerEntity>()
-                .FirstOrDefaultAsync(ds => ds.DatabaseServerId == databaseEntity.DatabaseServerId);
+        //     var databaseServer = await dbContext
+        //         .Set<DatabaseServerEntity>()
+        //         .FirstOrDefaultAsync(ds => ds.DatabaseServerId == databaseEntity.DatabaseServerId);
 
-            string commandText;
-            if (databaseServer?.IsLinkedServer == true)
-            {
-                var linkedServer = Sql.SanitizeSqlIdentifier(databaseServer.DatabaseServerHostName);
-                var escapedCommand = Sql.EscapeForDynamicSql(rawCommand);
-                commandText = $"exec('{escapedCommand}') at [{linkedServer}];";
-            }
-            else
-            {
-                commandText = rawCommand;
-            }
+        //     string commandText;
+        //     if (databaseServer?.IsLinkedServer == true)
+        //     {
+        //         var linkedServer = Sql.SanitizeSqlIdentifier(databaseServer.DatabaseServerHostName);
+        //         var escapedCommand = Sql.EscapeForDynamicSql(rawCommand);
+        //         commandText = $"exec('{escapedCommand}') at [{linkedServer}];";
+        //     }
+        //     else
+        //     {
+        //         commandText = rawCommand;
+        //     }
 
-            using var cmd = dbContext.Database.GetDbConnection().CreateCommand();
-            cmd.CommandText = commandText;
-            await dbContext.Database.OpenConnectionAsync();
-            await cmd.ExecuteNonQueryAsync();
-        }
+        //     using var cmd = dbContext.Database.GetDbConnection().CreateCommand();
+        //     cmd.CommandText = commandText;
+        //     await dbContext.Database.OpenConnectionAsync();
+        //     await cmd.ExecuteNonQueryAsync();
+        // }
     }
 }

--- a/DbLocator/Features/Databases/DeleteDatabase.cs
+++ b/DbLocator/Features/Databases/DeleteDatabase.cs
@@ -48,7 +48,9 @@ namespace DbLocator.Features.Databases
             cache?.Remove("databases");
 
             // TODO: Make this more specific
-            cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseEntity.DatabaseTypeId);
+            cache?.TryClearConnectionStringFromCache(
+                DatabaseTypeId: (int)databaseEntity.DatabaseTypeId
+            );
         }
 
         private static async Task DeleteDatabaseAsync(

--- a/DbLocator/Features/Databases/DeleteDatabase.cs
+++ b/DbLocator/Features/Databases/DeleteDatabase.cs
@@ -48,27 +48,6 @@ namespace DbLocator.Features.Databases
                 await DeleteDatabaseAsync(dbContext, databaseEntity);
 
             cache?.Remove("databases");
-        }
-
-        private static async Task DeleteDatabaseAsync(
-            DbLocatorContext dbContext,
-            DatabaseEntity databaseEntity
-        )
-        {
-            var databaseName = Sql.SanitizeSqlIdentifier(databaseEntity.DatabaseName);
-            var rawCommand = $"drop database [{databaseName}]";
-
-            var databaseServer = await dbContext
-                .Set<DatabaseServerEntity>()
-                .FirstOrDefaultAsync(ds => ds.DatabaseServerId == databaseEntity.DatabaseServerId);
-
-            string commandText;
-            if (databaseServer?.IsLinkedServer == true)
-            {
-                await DeleteDatabaseAsync(dbContext, databaseEntity);
-            }
-
-            cache?.Remove("databases");
 
             // TODO: Make this more specific
             cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseEntity.DatabaseTypeId);

--- a/DbLocator/Features/Databases/DeleteDatabase.cs
+++ b/DbLocator/Features/Databases/DeleteDatabase.cs
@@ -46,7 +46,7 @@ namespace DbLocator.Features.Databases
 
             if (command.DeleteDatabase == true)
             {
-                //await DeleteDatabaseAsync(dbContext, databaseEntity);
+                await DeleteDatabaseAsync(dbContext, databaseEntity);
             }
 
             cache?.Remove("databases");
@@ -55,34 +55,34 @@ namespace DbLocator.Features.Databases
             cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseEntity.DatabaseTypeId);
         }
 
-        // private static async Task DeleteDatabaseAsync(
-        //     DbLocatorContext dbContext,
-        //     DatabaseEntity databaseEntity
-        // )
-        // {
-        //     var databaseName = Sql.SanitizeSqlIdentifier(databaseEntity.DatabaseName);
-        //     var rawCommand = $"drop database [{databaseName}]";
+        private static async Task DeleteDatabaseAsync(
+            DbLocatorContext dbContext,
+            DatabaseEntity databaseEntity
+        )
+        {
+            var databaseName = Sql.SanitizeSqlIdentifier(databaseEntity.DatabaseName);
+            var rawCommand = $"drop database [{databaseName}]";
 
-        //     var databaseServer = await dbContext
-        //         .Set<DatabaseServerEntity>()
-        //         .FirstOrDefaultAsync(ds => ds.DatabaseServerId == databaseEntity.DatabaseServerId);
+            var databaseServer = await dbContext
+                .Set<DatabaseServerEntity>()
+                .FirstOrDefaultAsync(ds => ds.DatabaseServerId == databaseEntity.DatabaseServerId);
 
-        //     string commandText;
-        //     if (databaseServer?.IsLinkedServer == true)
-        //     {
-        //         var linkedServer = Sql.SanitizeSqlIdentifier(databaseServer.DatabaseServerHostName);
-        //         var escapedCommand = Sql.EscapeForDynamicSql(rawCommand);
-        //         commandText = $"exec('{escapedCommand}') at [{linkedServer}];";
-        //     }
-        //     else
-        //     {
-        //         commandText = rawCommand;
-        //     }
+            string commandText;
+            if (databaseServer?.IsLinkedServer == true)
+            {
+                var linkedServer = Sql.SanitizeSqlIdentifier(databaseServer.DatabaseServerHostName);
+                var escapedCommand = Sql.EscapeForDynamicSql(rawCommand);
+                commandText = $"exec('{escapedCommand}') at [{linkedServer}];";
+            }
+            else
+            {
+                commandText = rawCommand;
+            }
 
-        //     using var cmd = dbContext.Database.GetDbConnection().CreateCommand();
-        //     cmd.CommandText = commandText;
-        //     await dbContext.Database.OpenConnectionAsync();
-        //     await cmd.ExecuteNonQueryAsync();
-        // }
+            using var cmd = dbContext.Database.GetDbConnection().CreateCommand();
+            cmd.CommandText = commandText;
+            await dbContext.Database.OpenConnectionAsync();
+            await cmd.ExecuteNonQueryAsync();
+        }
     }
 }

--- a/DbLocator/Features/Databases/GetDatabases.cs
+++ b/DbLocator/Features/Databases/GetDatabases.cs
@@ -1,9 +1,9 @@
 using System.Text.Json;
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Databases;
 
@@ -16,7 +16,7 @@ internal sealed class GetDatabasesQueryValidator : AbstractValidator<GetDatabase
 
 internal class GetDatabases(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     public async Task<List<Database>> Handle(GetDatabasesQuery query)
@@ -37,7 +37,7 @@ internal class GetDatabases(
 
     private async Task<string> GetCachedData(string cacheKey)
     {
-        return cache != null ? await cache.GetStringAsync(cacheKey) : null;
+        return cache != null ? await cache.GetCachedData<string>(cacheKey) : null;
     }
 
     private static List<Database> DeserializeCachedData(string cachedData)
@@ -50,7 +50,7 @@ internal class GetDatabases(
         if (cache != null)
         {
             var serializedData = JsonSerializer.Serialize(databases);
-            await cache.SetStringAsync(cacheKey, serializedData);
+            await cache.CacheData(cacheKey, serializedData);
         }
     }
 

--- a/DbLocator/Features/Databases/UpdateDatabase.cs
+++ b/DbLocator/Features/Databases/UpdateDatabase.cs
@@ -1,8 +1,8 @@
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Databases;
 
@@ -31,7 +31,7 @@ internal sealed class UpdateDatabaseCommandValidator : AbstractValidator<UpdateD
 
 internal class UpdateDatabase(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task Handle(UpdateDatabaseCommand command)

--- a/DbLocator/Features/Databases/UpdateDatabase.cs
+++ b/DbLocator/Features/Databases/UpdateDatabase.cs
@@ -102,5 +102,8 @@ internal class UpdateDatabase(
         }
 
         cache?.Remove("databases");
+
+        // TODO: Make this more specific
+        cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseEntity.DatabaseTypeId);
     }
 }

--- a/DbLocator/Features/Databases/UpdateDatabase.cs
+++ b/DbLocator/Features/Databases/UpdateDatabase.cs
@@ -88,12 +88,13 @@ internal class UpdateDatabase(
         dbContext.Update(databaseEntity);
         await dbContext.SaveChangesAsync();
 
-        var commands = new List<string>();
         if (oldDatabaseName != command.DatabaseName && !string.IsNullOrEmpty(command.DatabaseName))
-            commands.Add($"alter database {oldDatabaseName} modify name = {command.DatabaseName}");
-
-        foreach (var commandText in commands)
         {
+            var oldDbName = Sql.SanitizeSqlIdentifier(oldDatabaseName);
+            var newDbName = Sql.SanitizeSqlIdentifier(command.DatabaseName);
+
+            var commandText = $"alter database [{oldDbName}] modify name = [{newDbName}]";
+
             using var cmd = dbContext.Database.GetDbConnection().CreateCommand();
             cmd.CommandText = commandText;
             await dbContext.Database.OpenConnectionAsync();

--- a/DbLocator/Features/Databases/UpdateDatabase.cs
+++ b/DbLocator/Features/Databases/UpdateDatabase.cs
@@ -102,6 +102,7 @@ internal class UpdateDatabase(
         }
 
         cache?.Remove("databases");
+        cache?.Remove("connections");
 
         // TODO: Make this more specific
         cache?.TryClearConnectionStringFromCache(DatabaseTypeId: databaseEntity.DatabaseTypeId);

--- a/DbLocator/Features/Tenants/AddTenant.cs
+++ b/DbLocator/Features/Tenants/AddTenant.cs
@@ -1,8 +1,8 @@
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Tenants;
 
@@ -26,10 +26,7 @@ internal sealed class AddTenantCommandValidator : AbstractValidator<AddTenantCom
     }
 }
 
-internal class AddTenant(
-    IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
-)
+internal class AddTenant(IDbContextFactory<DbLocatorContext> dbContextFactory, DbLocatorCache cache)
 {
     internal async Task<int> Handle(AddTenantCommand command)
     {

--- a/DbLocator/Features/Tenants/DeleteTenant.cs
+++ b/DbLocator/Features/Tenants/DeleteTenant.cs
@@ -41,5 +41,7 @@ internal class DeleteTenant(
         await dbContext.SaveChangesAsync();
 
         cache?.Remove("tenants");
+        cache?.TryClearConnectionStringFromCache(TenantCode: tenant.TenantCode);
+        cache?.TryClearConnectionStringFromCache(TenantId: tenant.TenantId);
     }
 }

--- a/DbLocator/Features/Tenants/DeleteTenant.cs
+++ b/DbLocator/Features/Tenants/DeleteTenant.cs
@@ -41,6 +41,7 @@ internal class DeleteTenant(
         await dbContext.SaveChangesAsync();
 
         cache?.Remove("tenants");
+        cache?.Remove("connections");
         cache?.TryClearConnectionStringFromCache(TenantCode: tenant.TenantCode);
         cache?.TryClearConnectionStringFromCache(TenantId: tenant.TenantId);
     }

--- a/DbLocator/Features/Tenants/DeleteTenant.cs
+++ b/DbLocator/Features/Tenants/DeleteTenant.cs
@@ -1,7 +1,7 @@
 using DbLocator.Db;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Tenants;
 
@@ -17,7 +17,7 @@ internal sealed class DeleteTenantCommandValidator : AbstractValidator<DeleteTen
 
 internal class DeleteTenant(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task Handle(DeleteTenantCommand command)

--- a/DbLocator/Features/Tenants/GetTenants.cs
+++ b/DbLocator/Features/Tenants/GetTenants.cs
@@ -2,9 +2,9 @@ using System.Text;
 using System.Text.Json;
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Tenants;
 
@@ -17,7 +17,7 @@ internal sealed class GetTenantsQueryValidator : AbstractValidator<GetTenantsQue
 
 internal class GetTenants(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task<List<Tenant>> Handle(GetTenantsQuery query)
@@ -38,7 +38,7 @@ internal class GetTenants(
 
     private async Task<string> GetCachedData(string cacheKey)
     {
-        return cache != null ? await cache.GetStringAsync(cacheKey) : null;
+        return cache != null ? await cache.GetCachedData<string>(cacheKey) : null;
     }
 
     private static List<Tenant> DeserializeCachedData(string cachedData)
@@ -51,7 +51,7 @@ internal class GetTenants(
         if (cache != null)
         {
             var serializedData = JsonSerializer.Serialize(tenants);
-            await cache.SetStringAsync(cacheKey, serializedData);
+            await cache.CacheData(cacheKey, serializedData);
         }
     }
 

--- a/DbLocator/Features/Tenants/GetTenants.cs
+++ b/DbLocator/Features/Tenants/GetTenants.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using DbLocator.Db;
 using DbLocator.Domain;

--- a/DbLocator/Features/Tenants/UpdateTenant.cs
+++ b/DbLocator/Features/Tenants/UpdateTenant.cs
@@ -61,6 +61,7 @@ internal class UpdateTenant(
         await dbContext.SaveChangesAsync();
 
         cache?.Remove("tenants");
+        cache?.Remove("connections");
         cache?.TryClearConnectionStringFromCache(TenantCode: tenant.TenantCode);
         cache?.TryClearConnectionStringFromCache(TenantId: tenant.TenantId);
     }

--- a/DbLocator/Features/Tenants/UpdateTenant.cs
+++ b/DbLocator/Features/Tenants/UpdateTenant.cs
@@ -61,5 +61,7 @@ internal class UpdateTenant(
         await dbContext.SaveChangesAsync();
 
         cache?.Remove("tenants");
+        cache?.TryClearConnectionStringFromCache(TenantCode: tenant.TenantCode);
+        cache?.TryClearConnectionStringFromCache(TenantId: tenant.TenantId);
     }
 }

--- a/DbLocator/Features/Tenants/UpdateTenant.cs
+++ b/DbLocator/Features/Tenants/UpdateTenant.cs
@@ -1,8 +1,8 @@
 using DbLocator.Db;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using FluentValidation;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Features.Tenants;
 
@@ -33,7 +33,7 @@ internal sealed class UpdateTenantCommandValidator : AbstractValidator<UpdateTen
 
 internal class UpdateTenant(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     internal async Task Handle(UpdateTenantCommand command)

--- a/DbLocator/Library/Connections.cs
+++ b/DbLocator/Library/Connections.cs
@@ -4,14 +4,13 @@ using DbLocator.Features.Connections;
 using DbLocator.Utilities;
 using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Library;
 
 internal class Connections(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
     Encryption encryption,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     private readonly AddConnection _addConnection = new(dbContextFactory, cache);

--- a/DbLocator/Library/DatabaseServers.cs
+++ b/DbLocator/Library/DatabaseServers.cs
@@ -1,14 +1,14 @@
 using DbLocator.Db;
 using DbLocator.Domain;
 using DbLocator.Features.DatabaseServers;
+using DbLocator.Utilities;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Library;
 
 internal class DatabaseServers(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     private readonly AddDatabaseServer _addDatabaseServer = new(dbContextFactory, cache);

--- a/DbLocator/Library/DatabaseTypes.cs
+++ b/DbLocator/Library/DatabaseTypes.cs
@@ -1,14 +1,14 @@
 using DbLocator.Db;
 using DbLocator.Domain;
 using DbLocator.Features.DatabaseTypes;
+using DbLocator.Utilities;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Library;
 
 internal class DatabaseTypes(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     private readonly AddDatabaseType _addDatabaseType = new(dbContextFactory, cache);

--- a/DbLocator/Library/DatabaseUsers.cs
+++ b/DbLocator/Library/DatabaseUsers.cs
@@ -3,14 +3,13 @@ using DbLocator.Domain;
 using DbLocator.Features.DatabaseUsers;
 using DbLocator.Utilities;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Library;
 
 internal class DatabaseUsers(
     IDbContextFactory<DbLocatorContext> dbContextFactory,
     Encryption encryption,
-    IDistributedCache cache
+    DbLocatorCache cache
 )
 {
     private readonly AddDatabaseUser _addDatabaseUser = new(dbContextFactory, encryption, cache);

--- a/DbLocator/Library/DatabaseUsersRoles.cs
+++ b/DbLocator/Library/DatabaseUsersRoles.cs
@@ -1,14 +1,18 @@
 using DbLocator.Db;
 using DbLocator.Domain;
 using DbLocator.Features.DatabaseUserRoles;
+using DbLocator.Utilities;
 using Microsoft.EntityFrameworkCore;
 
 namespace DbLocator.Library;
 
-internal class DatabaseUserRoles(IDbContextFactory<DbLocatorContext> dbContextFactory)
+internal class DatabaseUserRoles(
+    IDbContextFactory<DbLocatorContext> dbContextFactory,
+    DbLocatorCache cache
+)
 {
     private readonly AddDatabaseUserRole _addDatabaseUserRole = new(dbContextFactory);
-    private readonly DeleteDatabaseUserRole _deleteDatabaseUserRole = new(dbContextFactory);
+    private readonly DeleteDatabaseUserRole _deleteDatabaseUserRole = new(dbContextFactory, cache);
 
     internal async Task AddDatabaseUserRole(
         int databaseUserId,

--- a/DbLocator/Library/Databases.cs
+++ b/DbLocator/Library/Databases.cs
@@ -1,15 +1,12 @@
 using DbLocator.Db;
 using DbLocator.Domain;
 using DbLocator.Features.Databases;
+using DbLocator.Utilities;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Library;
 
-internal class Databases(
-    IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
-)
+internal class Databases(IDbContextFactory<DbLocatorContext> dbContextFactory, DbLocatorCache cache)
 {
     private readonly AddDatabase _addDatabase = new(dbContextFactory, cache);
     private readonly DeleteDatabase _deleteDatabase = new(dbContextFactory, cache);

--- a/DbLocator/Library/Tenants.cs
+++ b/DbLocator/Library/Tenants.cs
@@ -1,15 +1,12 @@
 using DbLocator.Db;
 using DbLocator.Domain;
 using DbLocator.Features.Tenants;
+using DbLocator.Utilities;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocator.Library;
 
-internal class Tenants(
-    IDbContextFactory<DbLocatorContext> dbContextFactory,
-    IDistributedCache cache
-)
+internal class Tenants(IDbContextFactory<DbLocatorContext> dbContextFactory, DbLocatorCache cache)
 {
     private readonly AddTenant _addTenant = new(dbContextFactory, cache);
     private readonly DeleteTenant _deleteTenant = new(dbContextFactory, cache);

--- a/DbLocator/Utilities/DbLocatorCache.cs
+++ b/DbLocator/Utilities/DbLocatorCache.cs
@@ -1,0 +1,73 @@
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace DbLocator.Utilities;
+
+internal class DbLocatorCache(IDistributedCache cache)
+{
+    private readonly IDistributedCache _cache = cache;
+
+    internal async Task<T> GetCachedData<T>(string cacheKey)
+    {
+        if (_cache == null)
+        {
+            return default;
+        }
+
+        var cachedData = _cache != null ? await _cache.GetStringAsync(cacheKey) : null;
+        return cachedData != null ? JsonSerializer.Deserialize<T>(cachedData) : default;
+    }
+
+    internal async Task CacheData(string cacheKey, object data)
+    {
+        if (_cache == null)
+        {
+            return;
+        }
+
+        var serializedData = JsonSerializer.Serialize(data);
+        await _cache.SetStringAsync(cacheKey, serializedData);
+    }
+
+    internal async Task CacheConnectionString(string cacheKey, string connectionString)
+    {
+        if (_cache == null)
+        {
+            return;
+        }
+
+        await _cache.SetStringAsync(cacheKey, connectionString);
+
+        // Add cacheKey to cached dictionary
+        var cacheKeys = await GetCachedData<List<string>>("connectionCacheKeys") ?? [];
+        cacheKeys.Add(cacheKey);
+        await CacheData("connectionCacheKeys", cacheKeys);
+    }
+
+    internal async Task Remove(string cacheKey)
+    {
+        if (_cache == null)
+        {
+            return;
+        }
+
+        await _cache.RemoveAsync(cacheKey);
+    }
+
+    internal async Task TryClearConnectionStringFromCache(string connectionCacheKeyPiece)
+    {
+        if (_cache == null)
+        {
+            return;
+        }
+
+        var cacheKeys = await GetCachedData<List<string>>("connectionCacheKeys") ?? [];
+        foreach (var cacheKey in cacheKeys)
+        {
+            if (cacheKey.Contains(connectionCacheKeyPiece))
+            {
+                await _cache.RemoveAsync(cacheKey);
+            }
+        }
+    }
+}

--- a/DbLocator/Utilities/PasswordGenerator.cs
+++ b/DbLocator/Utilities/PasswordGenerator.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/DbLocator/Utilities/Sql.cs
+++ b/DbLocator/Utilities/Sql.cs
@@ -1,0 +1,19 @@
+using System.Text.RegularExpressions;
+
+internal class Sql
+{
+    // Allow only alphanumeric and underscores
+    public static string SanitizeSqlIdentifier(string input)
+    {
+        if (Regex.IsMatch(input, @"^[a-zA-Z0-9_]+$"))
+            return input;
+
+        throw new ArgumentException($"Invalid SQL identifier: {input}");
+    }
+
+    // Escape single quotes for use inside dynamic EXEC ('' for one ')
+    public static string EscapeForDynamicSql(string input)
+    {
+        return input.Replace("'", "''");
+    }
+}

--- a/DbLocatorTests/ConnectionTests.cs
+++ b/DbLocatorTests/ConnectionTests.cs
@@ -1,6 +1,8 @@
 using DbLocator;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using DbLocatorTests.Fixtures;
+using Microsoft.Extensions.Caching.Distributed;
 
 namespace DbLocatorTests;
 
@@ -9,6 +11,7 @@ public class ConnectionTests(DbLocatorFixture dbLocatorFixture)
 {
     private readonly Locator _dbLocator = dbLocatorFixture.DbLocator;
     private readonly int _databaseServerId = dbLocatorFixture.LocalhostServerId;
+    private readonly DbLocatorCache _cache = dbLocatorFixture.LocatorCache;
 
     [Fact]
     public async Task AddConnection()
@@ -17,6 +20,52 @@ public class ConnectionTests(DbLocatorFixture dbLocatorFixture)
 
         var connections = await _dbLocator.GetConnections();
         Assert.Contains(connections, cn => cn.Id == connectionId);
+    }
+
+    [Fact]
+    public async Task VerifyConnectionsAreCached()
+    {
+        var connectionId = await GetConnectionId();
+
+        var connections = await _dbLocator.GetConnections();
+        Assert.Contains(connections, cn => cn.Id == connectionId);
+
+        var cachedConnections = await _cache.GetCachedData<List<Connection>>("connections");
+        Assert.NotNull(cachedConnections);
+
+        Assert.Contains(cachedConnections, cn => cn.Id == connectionId);
+    }
+
+    [Fact]
+    public async Task VerifyUpdatingDatabaseTypeClearsConnectionCache()
+    {
+        var connectionId = await GetConnectionId();
+
+        var connections = await _dbLocator.GetConnections();
+        Assert.Contains(connections, cn => cn.Id == connectionId);
+
+        var cachedConnections = await _cache.GetCachedData<List<Connection>>("connections");
+        Assert.NotNull(cachedConnections);
+
+        Assert.Contains(cachedConnections, cn => cn.Id == connectionId);
+
+        var databaseTypeName = TestHelpers.GetRandomString();
+        var databaseTypeId = await _dbLocator.AddDatabaseType(databaseTypeName);
+
+        var databaseName = TestHelpers.GetRandomString();
+        var databaseId = await _dbLocator.AddDatabase(
+            databaseName,
+            _databaseServerId,
+            databaseTypeId,
+            Status.Active
+        );
+
+        await _dbLocator.UpdateDatabaseType(databaseTypeId, "UpdatedDatabaseType");
+
+        var cachedConnectionsAfterUpdate = await _cache.GetCachedData<List<Connection>>(
+            "connections"
+        );
+        Assert.Null(cachedConnectionsAfterUpdate);
     }
 
     private async Task<int> GetConnectionId()

--- a/DbLocatorTests/DatabaseServerTests.cs
+++ b/DbLocatorTests/DatabaseServerTests.cs
@@ -1,4 +1,6 @@
 using DbLocator;
+using DbLocator.Domain;
+using DbLocator.Utilities;
 using DbLocatorTests.Fixtures;
 
 namespace DbLocatorTests;
@@ -7,7 +9,7 @@ namespace DbLocatorTests;
 public class DatabaseServerTests(DbLocatorFixture dbLocatorFixture)
 {
     private readonly Locator _dbLocator = dbLocatorFixture.DbLocator;
-
+    private readonly DbLocatorCache _cache = dbLocatorFixture.LocatorCache;
     private readonly string databaseServerName = TestHelpers.GetRandomString();
 
     [Fact]
@@ -48,5 +50,31 @@ public class DatabaseServerTests(DbLocatorFixture dbLocatorFixture)
             .ToList();
 
         Assert.Empty(databaseServers);
+    }
+
+    [Fact]
+    public async Task VerifyDatabaseServersAreCached()
+    {
+        var databaseServerIpAddress = TestHelpers.GetRandomIpAddressString();
+        var databaseServerId = await _dbLocator.AddDatabaseServer(
+            databaseServerName,
+            databaseServerIpAddress,
+            null,
+            null,
+            false
+        );
+
+        var databaseServers = (await _dbLocator.GetDatabaseServers())
+            .Where(x => x.Name == databaseServerName)
+            .ToList();
+
+        Assert.Single(databaseServers);
+        Assert.Equal(databaseServerName, databaseServers[0].Name);
+
+        var cachedDatabaseServers = await _cache.GetCachedData<List<DatabaseServer>>(
+            "databaseServers"
+        );
+        Assert.NotNull(cachedDatabaseServers);
+        Assert.Contains(cachedDatabaseServers, ds => ds.Id == databaseServerId);
     }
 }

--- a/DbLocatorTests/DatabaseTypeTests.cs
+++ b/DbLocatorTests/DatabaseTypeTests.cs
@@ -1,4 +1,6 @@
 using DbLocator;
+using DbLocator.Domain;
+using DbLocator.Utilities;
 using DbLocatorTests.Fixtures;
 
 namespace DbLocatorTests;
@@ -7,6 +9,7 @@ namespace DbLocatorTests;
 public class DatabaseTypeTests(DbLocatorFixture dbLocatorFixture)
 {
     private readonly Locator _dbLocator = dbLocatorFixture.DbLocator;
+    private readonly DbLocatorCache _cache = dbLocatorFixture.LocatorCache;
 
     [Fact]
     public async Task AddMultipleDatabaseTypesAndSearchByKeyWord()
@@ -57,5 +60,19 @@ public class DatabaseTypeTests(DbLocatorFixture dbLocatorFixture)
             .Where(x => x.Name == databaseTypeName2)
             .ToList();
         Assert.Single(newDatabaseTypes);
+    }
+
+    [Fact]
+    public async Task VerifyDatabaseTypesAreCached()
+    {
+        var databaseTypeName = TestHelpers.GetRandomString();
+        var databaseTypeId = await _dbLocator.AddDatabaseType(databaseTypeName);
+
+        var databaseTypes = await _dbLocator.GetDatabaseTypes();
+        Assert.Contains(databaseTypes, db => db.Name == databaseTypeName);
+
+        var cachedDatabaseTypes = await _cache.GetCachedData<List<DatabaseType>>("databaseTypes");
+        Assert.NotNull(cachedDatabaseTypes);
+        Assert.Contains(cachedDatabaseTypes, db => db.Name == databaseTypeName);
     }
 }

--- a/DbLocatorTests/Fixtures/LocatorFixture.cs
+++ b/DbLocatorTests/Fixtures/LocatorFixture.cs
@@ -1,11 +1,17 @@
 using DbLocator;
 using DbLocator.Db;
+using DbLocator.Utilities;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 namespace DbLocatorTests.Fixtures;
 
 public class DbLocatorFixture : IDisposable, IAsyncLifetime
 {
     public Locator DbLocator { get; private set; }
+    internal DbLocatorCache LocatorCache { get; private set; }
     public int LocalhostServerId { get; private set; }
 
     private const string connString =
@@ -13,7 +19,10 @@ public class DbLocatorFixture : IDisposable, IAsyncLifetime
 
     public DbLocatorFixture()
     {
-        DbLocator = new Locator(connString);
+        var options = Options.Create<MemoryDistributedCacheOptions>(new());
+        var memCache = new MemoryDistributedCache(options, NullLoggerFactory.Instance);
+        LocatorCache = new DbLocatorCache(memCache);
+        DbLocator = new Locator(connString, null, memCache);
     }
 
     public void Dispose() { }

--- a/DbLocatorTests/TenantTests.cs
+++ b/DbLocatorTests/TenantTests.cs
@@ -1,5 +1,6 @@
 ﻿using DbLocator;
 using DbLocator.Domain;
+using DbLocator.Utilities;
 using DbLocatorTests.Fixtures;
 
 namespace DbLocatorTests;
@@ -8,6 +9,7 @@ namespace DbLocatorTests;
 public class TenantTests(DbLocatorFixture dbLocatorFixture)
 {
     private readonly Locator _dbLocator = dbLocatorFixture.DbLocator;
+    private readonly DbLocatorCache _cache = dbLocatorFixture.LocatorCache;
 
     [Fact]
     public async Task AddMultipleTenantsAndSearchByKeyWord()
@@ -23,5 +25,20 @@ public class TenantTests(DbLocatorFixture dbLocatorFixture)
         var tenants = (await _dbLocator.GetTenants()).ToList();
         Assert.Contains(tenants, t => t.Name == tenantName1 && t.Code == tenantCode1);
         Assert.Contains(tenants, t => t.Name == tenantName2 && t.Code == tenantCode2);
+    }
+
+    [Fact]
+    public async Task VerifyTenantsAreCached()
+    {
+        var tenantName = TestHelpers.GetRandomString();
+        var tenantCode = TestHelpers.GetRandomString();
+        var tenantId = await _dbLocator.AddTenant(tenantName, tenantCode, Status.Active);
+
+        var tenants = await _dbLocator.GetTenants();
+        Assert.Contains(tenants, t => t.Id == tenantId);
+
+        var cachedTenants = await _cache.GetCachedData<List<Tenant>>("tenants");
+        Assert.NotNull(cachedTenants);
+        Assert.Contains(cachedTenants, t => t.Id == tenantId);
     }
 }


### PR DESCRIPTION
Replace the use of `IDistributedCache` with a custom `DbLocatorCache` wrapper for improved caching management and remove connection strings from the cache upon deletion of related entities.